### PR TITLE
simwrapper is on conda-forge now; remove pip install rules & docs

### DIFF
--- a/conda-environments/activitysim-dev.yml
+++ b/conda-environments/activitysim-dev.yml
@@ -29,8 +29,4 @@ dependencies:
 - git
 - gh
 - bump2version
-
-- pip:
-  - -e ..
-# Placeholder until available on conda-forge 
-  - simwrapper > 1.7
+- simwrapper > 1.7

--- a/conda-environments/activitysim-test-larch.yml
+++ b/conda-environments/activitysim-test-larch.yml
@@ -25,7 +25,4 @@ dependencies:
 - pytest-regressions
 - xarray
 - sharrow
-
-- pip:
-# Placeholder until available on conda-forge 
-  - simwrapper > 1.7
+- simwrapper > 1.7

--- a/conda-environments/activitysim-test.yml
+++ b/conda-environments/activitysim-test.yml
@@ -22,7 +22,4 @@ dependencies:
 - coveralls
 - pycodestyle
 - pytest-regressions
-
-- pip:
-# Placeholder until available on conda-forge 
-  - simwrapper > 1.7
+- simwrapper > 1.7

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -542,12 +542,16 @@ Trip-level skim data are also made available in the preprocessing stage by attac
 
 Install and Run Simwrapper
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-The SimWrapper Python package, which contains convience functions for initiating the SimWrapper app in the browser and a local file server for accessing summary tables from this app, is automatically installed as a dependency of ActivitySim. However, you can also use SimWrapper independent of ActivitySim to, for example, visualize summaries on a different workstation. SimWrapper is available on pip:
+The SimWrapper Python package, which contains convenience functions for initiating the SimWrapper app in the browser and a local file server for accessing summary tables from this app, is automatically installed as a dependency of ActivitySim. However, you can also use SimWrapper independent of ActivitySim to, for example, visualize summaries on a different workstation. SimWrapper is available on both conda-forge and pip:
 ::
+
+  > conda install -c conda-forge simwrapper
+
+or
 
   > pip install simwrapper
 
-The latest information about the Simwrapper package is available on its `PyPI page <https://pypi.org/project/simwrapper/1.2.0/>`_.
+The latest information about the Simwrapper package is available on its `PyPI page <https://pypi.org/project/simwrapper/>`_.
 
 To run SimWrapper, navigate on the command line to ``output\summarize`` within the model directory, or a directory where you may have copied outputs, and run:
 ::


### PR DESCRIPTION
The conda-environment YAMLs had special-cased pip commands for installing simwrapper. SimWrapper is now on conda-forge, so it can be installed directly.

Also updated docs/core.rst to reference conda install command instead of pip.
