### PR TITLE
relax progressive checks for categorical dtypes

### DIFF
--- a/activitysim/core/workflow/checkpoint.py
+++ b/activitysim/core/workflow/checkpoint.py
@@ -1050,7 +1050,7 @@ class Checkpoints(StateAccessor):
                             )
                         except Exception as err2:
                             raise AssertionError(
-                                f"checkpoint {checkpoint_name!r} table {table_name!r}, {str(err)}"
+                                f"checkpoint {checkpoint_name!r} table {table_name!r}, {str(err)}\nfrom: {str(err2)}"
                             )
                         else:
                             warnings.warn(

--- a/activitysim/core/workflow/state.py
+++ b/activitysim/core/workflow/state.py
@@ -1082,16 +1082,23 @@ class State:
                 missing_df_str_columns = []
 
             # union categoricals
-            for c in table_df.columns.intersection(df.columns):
-                if isinstance(table_df[c].dtype, pd.api.types.CategoricalDtype):
-                    if isinstance(df[c].dtype, pd.api.types.CategoricalDtype):
-                        from pandas.api.types import union_categoricals
+            for c in table_df.columns:
+                if c in df.columns:
+                    if isinstance(table_df[c].dtype, pd.api.types.CategoricalDtype):
+                        if isinstance(df[c].dtype, pd.api.types.CategoricalDtype):
+                            from pandas.api.types import union_categoricals
 
-                        uc = union_categoricals([table_df[c], df[c]])
-                        table_df[c] = pd.Categorical(
-                            table_df[c], categories=uc.categories
-                        )
-                        df[c] = pd.Categorical(df[c], categories=uc.categories)
+                            uc = union_categoricals([table_df[c], df[c]])
+                            table_df[c] = pd.Categorical(
+                                table_df[c], categories=uc.categories
+                            )
+                            df[c] = pd.Categorical(df[c], categories=uc.categories)
+                else:
+                    # when the existing categorical type has an empty string as a category,
+                    # we will use that as the missing value instead of NaN
+                    if isinstance(table_df[c].dtype, pd.api.types.CategoricalDtype):
+                        if "" in table_df[c].cat.categories:
+                            missing_df_str_columns.append(c)
 
             # preserve existing column order
             df = pd.concat([table_df, df], sort=False, axis=axis)

--- a/activitysim/examples/external_example_manifest.yaml
+++ b/activitysim/examples/external_example_manifest.yaml
@@ -13,11 +13,11 @@
 #
 
 prototype_mtc:
-  url: https://github.com/jpn--/activitysim-prototype-mtc/archive/refs/tags/v1.3.1.tar.gz
+  url: https://github.com/ActivitySim/activitysim-prototype-mtc/archive/refs/tags/v1.3.1.tar.gz
   sha256: ec53c6e72da1444bd5808de8c644cea75db284dfcc419b776575ba532b3ccb87
   assets:
     test/prototype_mtc_reference_pipeline.zip:
-      url: https://github.com/jpn--/activitysim-prototype-mtc/releases/download/v1.3.1/prototype_mtc_reference_pipeline.zip
+      url: https://github.com/ActivitySim/activitysim-prototype-mtc/releases/download/v1.3.1/prototype_mtc_reference_pipeline.zip
       sha256: 394e5b403d4c61d5214493cefe161432db840ba4967c23c999d914178d43a1f0
 
 estimation_example:


### PR DESCRIPTION
You've got a lot of tests failing because the stored "progressive" check results don't have categorical datatypes encoded in them, but the revised code does.  We can patch this for now by just checking that the *values* match and not the datatype in the output.  Then we can in the near future regenerate the reference data pipelines and simultaneously turn the `strict_categorical` setting on.