### PR TITLE
Resolve package version conflicts

### DIFF
--- a/.github/workflows/branch-docs.yml
+++ b/.github/workflows/branch-docs.yml
@@ -19,12 +19,10 @@ jobs:
         with:
           fetch-depth: 0  # get all tags, lets setuptools_scm do its thing
 
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v2
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
-          use-mamba: true
           python-version: "3.10"
           activate-environment: docbuild
           auto-activate-base: false
@@ -40,7 +38,7 @@ jobs:
         id: cache
 
       - name: Update environment
-        run: mamba env update --verbose -n docbuild -f conda-environments/docbuild.yml
+        run: conda env update --verbose -n docbuild -f conda-environments/docbuild.yml
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Install activitysim

--- a/conda-environments/activitysim-dev-base.yml
+++ b/conda-environments/activitysim-dev-base.yml
@@ -33,6 +33,7 @@ dependencies:
 - jupyterlab
 - larch = 5.7.*
 - matplotlib
+- multimethod <2.0
 - myst-parser  # allows markdown in sphinx
 - nbconvert
 - nbformat

--- a/conda-environments/activitysim-dev.yml
+++ b/conda-environments/activitysim-dev.yml
@@ -29,6 +29,7 @@ dependencies:
 - jupyterlab
 - larch = 5.7.*
 - matplotlib
+- multimethod <2.0
 - myst-parser  # allows markdown in sphinx
 - nbconvert
 - nbformat

--- a/conda-environments/docbuild.yml
+++ b/conda-environments/docbuild.yml
@@ -25,6 +25,7 @@ dependencies:
 - jupyterlab
 - larch >=5.5.3
 - matplotlib
+- multimethod <2.0
 - myst-nb
 - myst-parser
 - numba >= 0.57

--- a/conda-environments/github-actions-tests.yml
+++ b/conda-environments/github-actions-tests.yml
@@ -12,6 +12,7 @@ dependencies:
 - cytoolz = 0.12.2
 - dask = 2023.3.2
 - isort = 5.12.0
+- multimethod <2.0
 - nbmake = 1.4.6
 - numba = 0.57.*
 - numpy = 1.23.5

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -24,7 +24,7 @@ installs a variety of things on your system, and it is quite likely to be flagge
 Windows, anti-virus, or institutional IT policies as "unusual" software, which
 may require special treatment to actually install and use.
 
-Download the installer from GitHub `here <https://github.com/ActivitySim/activitysim/releases/download/v1.2.0/Activitysim-1.2.0-Windows-x86_64.exe>`_.
+Download the installer from GitHub `here <https://github.com/ActivitySim/activitysim/releases/download/v1.3.1/Activitysim-1.3.1-Windows-x86_64.exe>`_.
 It is strongly recommended to choose the option to install "for me only", as this
 should not require administrator privileges on your machine.  Pay attention
 to the *complete path* of the installation location. You will need to know

--- a/docs/users-guide/modelsetup.rst
+++ b/docs/users-guide/modelsetup.rst
@@ -134,7 +134,7 @@ installs a variety of things on your system, and it is quite likely to be flagge
 Windows, anti-virus, or institutional IT policies as "unusual" software, which
 may require special treatment to actually install and use.
 
-Download the installer from GitHub `here <https://github.com/ActivitySim/activitysim/releases/download/v1.2.0/Activitysim-1.2.0-Windows-x86_64.exe>`_.
+Download the installer from GitHub `here <https://github.com/ActivitySim/activitysim/releases/download/v1.3.1/Activitysim-1.3.1-Windows-x86_64.exe>`_.
 It is strongly recommended to choose the option to install "for me only", as this
 should not require administrator privileges on your machine.  Pay attention
 to the *complete path* of the installation location. You will need to know

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ name = "activitysim"
 dynamic = ["version"]
 dependencies = [
     "cytoolz >= 0.8.1",
+    "multimethod <2.0",
     "numba >= 0.57",
     "numpy >= 1.16.1, <2",
     "openmatrix >= 0.3.4.1",


### PR DESCRIPTION
This PR limits multimethod version to 2.0 and earlier, and updates the python versions in documentation to address the following issues.

1. The overload function, required by pandera, has been removed in [recent versions](https://github.com/coady/multimethod/releases/tag/v2.0) of the multimethod package, causing import errors as noted in https://github.com/ActivitySim/activitysim/issues/919

2. Python 3.9 does not support the | operator for type unions, which is used in some sharrow modules. Upgrading to Python 3.10 or later resolves this issue, as mentioned in https://github.com/ActivitySim/activitysim/issues/921

